### PR TITLE
Close browser whenever testcase failed

### DIFF
--- a/wtrobot/commad_parser.py
+++ b/wtrobot/commad_parser.py
@@ -139,6 +139,7 @@ class commmandParser:
                                 testcase_no, step
                             )
                         )
+                        self.obj_action.closebrowser(testcase_list[index][step])
                         break
 
                 else:
@@ -149,6 +150,8 @@ class commmandParser:
                             step,
                         )
                     )
+                    self.obj_action.closebrowser(testcase_list[index][step])
+                    break
 
         return testcase_list
 


### PR DESCRIPTION
Close browser in case of INVALID COMMAND/action and/or test step failure

**Test 1:** 
Tried using wrong action (`action: ho` instead of `action: hover`)
Expected:
Browser should closed with invalid action error message
Actual:
Browser remains open even after error

**Test 2:**
Tried using wrong target (`target: _anything_)
Expected:
Browser should closed with error message
Actual:
Browser remains open even after error

Resolution/Fix:
Added call to close browser function wherever require.
